### PR TITLE
Adding support to accept attribute in file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Rules are not defined by default, but they can be set via attributes or classes 
 > - step: number
 > - minDate: Date
 > - maxDate: Date
+> - accepts: string
 
 
 These attributes can be used
@@ -235,6 +236,7 @@ Example:
     <input id="email" type="email" name="email" class="required">
     <input id="date" type="date" name="date" min="2011-12-30" class="required">
     <input id="number" type="number" name="number" min="2" max="20" step="2">
+    <input id="file" type="file" name="file" accept=".csv">
 ```
 
 * type="email" or class="email" to validate as email

--- a/example/bootstrap.html
+++ b/example/bootstrap.html
@@ -72,7 +72,7 @@
                             <label for="file" class="col-sm-2 control-label">File (html, css, txt):</label>
 
                             <div class="col-sm-4">
-                                <input name="file" type="file" class="form-control" id="file" multiple>
+                                <input name="file" accept=".png" type="file" class="form-control" id="file" multiple>
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/lib/get-options.js
+++ b/src/lib/get-options.js
@@ -53,6 +53,12 @@ export function getInputRules(input) {
         if (max) rules.max = max;
     }
 
+    if (input.type === 'file') {
+        if (input.hasAttribute('accept') && /\.[(a-z|0-9)]*/.test(input.accept)) {
+            rules.extension = input.accept.substring(1, input.accept.length);
+        }
+    }
+
     if (regexp) rules.regexp = regexp;
     if (step) rules.step = step;
 

--- a/tests/get-options.js
+++ b/tests/get-options.js
@@ -102,5 +102,14 @@ describe('Get options', () => {
                 maxDate: new Date('2019/04/01'),
             });
         });
+
+        it('Should return file input rules', () => {
+            input.setAttribute('type', 'file');
+            input.setAttribute('accept', '.csv');
+
+            should(getInputRules(input)).be.deepEqual({
+                extension: 'csv'
+            });
+        });
     });
 });


### PR DESCRIPTION
Now jedi-validate can handle with attribute accept in file input.

closes #72  